### PR TITLE
Update license-mapping.json BSD-3-Clause 

### DIFF
--- a/src/main/resources/license-mapping.json
+++ b/src/main/resources/license-mapping.json
@@ -58,7 +58,7 @@
       "The New BSD License",
       "3-Clause BSD License",
       "BSD 3-clause New License",
-      "BSD License",
+      "BSD License 2.0",
       "EDL 1.0",
       "Eclipse Distribution License - v 1.0",
       "Eclipse Distribution License v. 1.0",


### PR DESCRIPTION
BSD-3-Clause and BSD-4-Clause both had the name "BSD License", s.t. an unique mapping was not possible. The BSD-4-Clause is the "original" BSD-Clause, while BSD-3 is the "2.0". Therefore, I changed the name "BSD License" for the BSD-3-Clause to "BSD License 2.0".